### PR TITLE
Update numpy<2 and onnxruntime<2 for compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'tokenizers',
-        'onnxruntime',
-        'numpy',
+        'onnxruntime<2',
+        'numpy<2',
         'requests',
         'tqdm',
         'llama-cpp-python==0.2.67'


### PR DESCRIPTION
numpy v2.0 is out.
https://numpy.org/doc/stable/release/2.0.0-notes.html However onnxruntime only supports v1.