### PR TITLE
Add a warning, when the provided max_length arg > max

### DIFF
--- a/flashrank/Ranker.py
+++ b/flashrank/Ranker.py
@@ -117,7 +117,14 @@ class Ranker:
         tokens_map = json.load(open(str(self.model_dir / "special_tokens_map.json")))
         tokenizer = Tokenizer.from_file(str(self.model_dir / "tokenizer.json"))
 
-        tokenizer.enable_truncation(max_length=min(tokenizer_config["model_max_length"], max_length))
+        effective_max_length = min(tokenizer_config["model_max_length"], max_length)
+        if effective_max_length < max_length:
+            self.logger.warning(
+                f"Desired max length ({max_length}) exceeds model max length "
+                f"({tokenizer_config['model_max_length']}). Using {effective_max_length}."
+            )
+
+        tokenizer.enable_truncation(max_length=effective_max_length)
         tokenizer.enable_padding(pad_id=config["pad_token_id"], pad_token=tokenizer_config["pad_token"])
 
         for token in tokens_map.values():


### PR DESCRIPTION
See the [following PR](https://github.com/PrithivirajDamodaran/FlashRank/pull/31) and [this comment](https://github.com/PrithivirajDamodaran/FlashRank/pull/31).

This PR addresses the following issue when using the Crossencoder Rerankers:

- I tried to use the crossencoder models for my large document chunks. They are up to 1024 tokens long (openai tokenizers) and when first blindly using the the library I didn't notice my chunks were truncated for reranking and I was wondering why the reranked results made no sense. I had to look into your library in detail and into the models config json files to figure out the token limit for these crossencoder models and I would have found it helpful to just receive a warning. In the end, I had to use sliding window reranking over my large chunks to rerank every text passage with the crossencoders.