### PR TITLE
Fix: rank extraction by stripping square brackets in listwise ranking

### DIFF
--- a/flashrank/Ranker.py
+++ b/flashrank/Ranker.py
@@ -210,7 +210,7 @@ class Ranker:
             raw_ranks = self.llm_model.create_chat_completion(messages)
             results = []
             for rank in raw_ranks["choices"][0]["message"]["content"].split(" > "):
-                results.append(result_map[int(rank[1])])
+                results.append(result_map[int(rank.strip("[]"))])
             return results    
 
         # self.session will be instantiated for ONNX based pairwise CE models


### PR DESCRIPTION
This update fixes the rank extraction logic in the results appending process by replacing `rank[1]` with `rank.strip("[]")` to handle rank values more effectively.

Refer to the links below for the original PR and the discussion where this issue was identified:

Original PR
- https://github.com/PrithivirajDamodaran/FlashRank/pull/33