### PR TITLE
feat: Allow to download model from mirror site

### DIFF
--- a/flashrank/Config.py
+++ b/flashrank/Config.py
@@ -1,8 +1,8 @@
 # Moved to HF - My cloud bucket and $ wont be abused anymore :-)
 # THE HF Repo is UNDER CC-BY-SA LICENSE. USE APPROPRIATELY.
 import os
-hf_endpoint = os.environ.get('HF_ENDPOINT', default='https://huggingface.co')
-model_url = hf_endpoint.rstrip("/") + '/prithivida/flashrank/resolve/main/{}.zip'
+hf_endpoint = os.environ.get('HF_ENDPOINT', default='https://huggingface.co').rstrip("/")
+model_url = f'{hf_endpoint}/prithivida/flashrank/resolve/main/{{}}.zip'
 listwise_rankers = {'rank_zephyr_7b_v1_full'}
 
 default_cache_dir = "/tmp"

--- a/flashrank/Config.py
+++ b/flashrank/Config.py
@@ -1,6 +1,8 @@
 # Moved to HF - My cloud bucket and $ wont be abused anymore :-)
 # THE HF Repo is UNDER CC-BY-SA LICENSE. USE APPROPRIATELY.
-model_url = 'https://huggingface.co/prithivida/flashrank/resolve/main/{}.zip'
+import os
+hf_endpoint = os.environ.get('HF_ENDPOINT', default='https://huggingface.co')
+model_url = hf_endpoint.rstrip("/") + '/prithivida/flashrank/resolve/main/{}.zip'
 listwise_rankers = {'rank_zephyr_7b_v1_full'}
 
 default_cache_dir = "/tmp"

--- a/flashrank/Config.py
+++ b/flashrank/Config.py
@@ -1,8 +1,10 @@
 # Moved to HF - My cloud bucket and $ wont be abused anymore :-)
 # THE HF Repo is UNDER CC-BY-SA LICENSE. USE APPROPRIATELY.
 import os
-hf_endpoint = os.environ.get('HF_ENDPOINT', default='https://huggingface.co').rstrip("/")
-model_url = f'{hf_endpoint}/prithivida/flashrank/resolve/main/{{}}.zip'
+from urllib.parse import urljoin
+
+hf_endpoint = os.environ.get('HF_ENDPOINT', default='https://huggingface.co')
+model_url = urljoin(hf_endpoint, 'prithivida/flashrank/resolve/main/{}.zip')
 listwise_rankers = {'rank_zephyr_7b_v1_full'}
 
 default_cache_dir = "/tmp"


### PR DESCRIPTION
Many Chinese users, including myself, cannot download models from https://huggingface.co. Can we configure the HF_ENDPOINT environment variable to use mirror sites like https://hf-mirror.com/prithivida/flashrank/tree/main?